### PR TITLE
upgrade binary version

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,10 +6,10 @@ DEPENDENCIES
   yum-epel
 
 GRAPH
-  apt (2.6.1)
-  build-essential (2.1.3)
-  monit (1.6.0)
+  apt (2.7.0)
+  build-essential (2.2.3)
+  monit (1.6.1)
     build-essential (>= 0.0.0)
-  yum (3.5.2)
+  yum (3.5.4)
   yum-epel (0.6.0)
     yum (~> 3.0)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -98,7 +98,7 @@ default["monit"]["source"]["compiler_optimized"] = true
 default["monit"]["binary_install"] = false
 default["monit"]["binary_uninstall"] = false
 
-default["monit"]["binary"]["version"] = "5.11"
+default["monit"]["binary"]["version"] = "5.12.2"
 default["monit"]["binary"]["prefix"] = "/usr"
-default["monit"]["binary"]["url"] = "http://mmonit.com/monit/dist/binary/5.11/monit-5.11-linux-x64.tar.gz"
-default["monit"]["binary"]["checksum"] = "bee00da32dbf4c948587277ac66bac9c68373aff6a15924b632cf9508e097783"
+default["monit"]["binary"]["url"] = "http://d1m352yddr2wlq.cloudfront.net/source-packages/monit-#{node["monit"]["binary"]["version"]}-linux-x64.tar.gz"
+default["monit"]["binary"]["checksum"] = "4908143752d0ee5081a50389a9206b7c905f9f8922a062a208fecf6e729a3c77"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Configures monit"
 long_description  "Please refer to README.md"
-version           "1.6.0"
+version           "1.6.1"
 
 recipe "monit", "Sets up the service definition and default checks."
 recipe "monit::install_source", "Compiles and installs monit from source."


### PR DESCRIPTION
@articulate/web-ops no more 5.11 from the download url, getting 404 not found error on chef runs with monit included.

![image](http://media.giphy.com/media/13ma90Tvwx7zm8/giphy.gif)